### PR TITLE
Link windows terminal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ I've always loved coloring. Now it's time to design my color schemes.
 - [PyCharm or IntelliJ IDEA](configs/IntelliJ)
 - [Slack](configs/Slack)
 - [Visual Studio Code](https://github.com/minmul117/vscode-sublette) by [Park GiSung](https://github.com/minmul117)
+- [Windows Terminal](https://windowsterminalthemes.dev/?theme=Sublette)
 
 ## For Terminal (base)
 


### PR DESCRIPTION
I linked Sublette [windows terminal theme page (updated)](https://windowsterminalthemes.dev/?theme=Sublette) and  [iterm2colorschemes.com (not updated yet)](https://github.com/mbadolato/iTerm2-Color-Schemes/pull/287). It will be easier for users to find.